### PR TITLE
Fix Some Latex Rendering Problem  in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Enable a personal instance，get the following environment parameters for config
   <img src="./img/2.png" style="zoom:50%;" />
 </div>
 
-- $\text {ALIYUN_REGISTRY_PASSWORD}$：Password，Set when creating a personal instance.
-- $\text {ALIYUN_NAME_SPACE}$：namespace, `solisamicus-images`.
-- $\text {ALIYUN_REGISTRY_USER}$：Username, `solisamicus`.
-- $\text {ALIYUN_REGISTRY}$：Repository Address, `registry.cn-wulanchabu.aliyuncs.com`.
+- $\text {ALIYUN\_REGISTRY\_PASSWORD}$：Password，Set when creating a personal instance.
+- $\text {ALIYUN\_NAME\_SPACE}$：namespace, `solisamicus-images`.
+- $\text {ALIYUN\_REGISTRY\_USER}$：Username, `solisamicus`.
+- $\text {ALIYUN\_REGISTRY}$：Repository Address, `registry.cn-wulanchabu.aliyuncs.com`.
 
 ## Fork Project
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Enable a personal instance，get the following environment parameters for config
   <img src="./img/2.png" style="zoom:50%;" />
 </div>
 
-- $\text {ALIYUN\_REGISTRY\_PASSWORD}$：Password，Set when creating a personal instance.
-- $\text {ALIYUN\_NAME\_SPACE}$：namespace, `solisamicus-images`.
-- $\text {ALIYUN\_REGISTRY\_USER}$：Username, `solisamicus`.
-- $\text {ALIYUN\_REGISTRY}$：Repository Address, `registry.cn-wulanchabu.aliyuncs.com`.
+- <span style="font-family: 'Times New Roman', Times, serif;">ALIYUN_REGISTRY_PASSWORD</span>：Password，Set when creating a personal instance.
+- <span style="font-family: 'Times New Roman', Times, serif;">ALIYUN_NAME_SPACE</span>：namespace, `solisamicus-images`.
+- <span style="font-family: 'Times New Roman', Times, serif;">ALIYUN_NAME_SPACE</span>：Username, `solisamicus`.
+- <span style="font-family: 'Times New Roman', Times, serif;">ALIYUN_NAME_SPACE</span>：Repository Address, `registry.cn-wulanchabu.aliyuncs.com`.
 
 ## Fork Project
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Enable a personal instance，get the following environment parameters for config
 
 - <span style="font-family: 'Times New Roman', Times, serif;">ALIYUN_REGISTRY_PASSWORD</span>：Password，Set when creating a personal instance.
 - <span style="font-family: 'Times New Roman', Times, serif;">ALIYUN_NAME_SPACE</span>：namespace, `solisamicus-images`.
-- <span style="font-family: 'Times New Roman', Times, serif;">ALIYUN_NAME_SPACE</span>：Username, `solisamicus`.
-- <span style="font-family: 'Times New Roman', Times, serif;">ALIYUN_NAME_SPACE</span>：Repository Address, `registry.cn-wulanchabu.aliyuncs.com`.
+- <span style="font-family: 'Times New Roman', Times, serif;">ALIYUN_REGISTRY_USER</span>：Username, `solisamicus`.
+- <span style="font-family: 'Times New Roman', Times, serif;">ALIYUN_REGISTRY</span>：Repository Address, `registry.cn-wulanchabu.aliyuncs.com`.
 
 ## Fork Project
 


### PR DESCRIPTION
![image](https://github.com/SolisAmicus/docker-image-sync/assets/51307853/be915e54-4f4a-452c-9370-8329e66a25d0)
Use HTML to replace the previous latex '$' syntax to avoid the problem on the picture.
And in the markdown preview of github the support of latex is not very well.
![image](https://github.com/SolisAmicus/docker-image-sync/assets/51307853/e12baddb-038b-43ae-861f-618012a35f05)
